### PR TITLE
add clojurescript, clojure.cljc, and edn examples

### DIFF
--- a/clojure.cljc
+++ b/clojure.cljc
@@ -1,0 +1,8 @@
+(ns core
+  (:require [core.utils :refer [log dangerous!]]))
+
+(try
+  (dangerous!)
+  (catch #?(:clj Exception
+            :cljs :default) e
+    (log e)))

--- a/clojurescript.cljs
+++ b/clojurescript.cljs
@@ -1,0 +1,13 @@
+(ns core)
+
+(defn hello
+  ([] (hello "world!"))
+  ([x] (.log js/console (str "hello " x))))
+
+(def database
+  {:users [{:firstname "Magnus" :lastname "Pym"}
+           {:firstname "Jack" :lastname "Brotherhood"}]})
+
+(->> (:users database)
+     (map :firstname)
+     (map hello))

--- a/edn.edn
+++ b/edn.edn
@@ -1,0 +1,4 @@
+{:foo "bar"
+ :list (1 2 3)
+ :boolean true
+ :id #uuid "601b69a9-cad8-44fc-ba5c-aaf16037929f"}


### PR DESCRIPTION
these all follow clojure syntax highlighting rules. would it be more conventional to name the files like `clojure.cljs`, `clojure.edn`, and `clojure.cljc`?

companion desktop PR: https://github.com/desktop/desktop/pull/3610